### PR TITLE
Rename to match Cryostat project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.redhat.jfr.datasource</groupId>
+  <groupId>io.cryostat</groupId>
   <artifactId>jfr-datasource</artifactId>
   <version>2.0.0-SNAPSHOT</version>
   <name>JFR Datasource</name>

--- a/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
+++ b/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.events;
+package io.cryostat.jfr.datasource.events;
 
 import java.io.File;
 import java.io.IOException;
@@ -6,9 +6,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
-
-import com.redhat.jfr.json.JsonUtils;
-import com.redhat.jfr.server.Query;
 
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItem;
@@ -29,6 +26,8 @@ import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.cryostat.jfr.datasource.json.JsonUtils;
+import io.cryostat.jfr.datasource.server.Query;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 

--- a/src/main/java/io/cryostat/jfr/datasource/json/JsonUtils.java
+++ b/src/main/java/io/cryostat/jfr/datasource/json/JsonUtils.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.json;
+package io.cryostat.jfr.datasource.json;
 
 public class JsonUtils {
   public static final String EMPTY_ARRAY = "[]";

--- a/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.server;
+package io.cryostat.jfr.datasource.server;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,8 +12,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
-import com.redhat.jfr.events.RecordingService;
-
+import io.cryostat.jfr.datasource.events.RecordingService;
 import io.quarkus.vertx.web.Route;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/io/cryostat/jfr/datasource/server/Query.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Query.java
@@ -1,11 +1,10 @@
-package com.redhat.jfr.server;
+package io.cryostat.jfr.datasource.server;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 
-import com.redhat.jfr.utils.ArgRunnable;
-
+import io.cryostat.jfr.datasource.utils.ArgRunnable;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 

--- a/src/main/java/io/cryostat/jfr/datasource/server/Target.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Target.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.server;
+package io.cryostat.jfr.datasource.server;
 
 public class Target {
   private final String target;

--- a/src/main/java/io/cryostat/jfr/datasource/utils/ArgRunnable.java
+++ b/src/main/java/io/cryostat/jfr/datasource/utils/ArgRunnable.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.utils;
+package io.cryostat.jfr.datasource.utils;
 
 public interface ArgRunnable<T> {
   public void run(T target);

--- a/src/test/java/io/cryostat/jfr/datasource/tests/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/tests/DatasourceTest.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.tests;
+package io.cryostat.jfr.datasource.tests;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
@@ -7,9 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Files;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;

--- a/src/test/java/io/cryostat/jfr/datasource/tests/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/tests/NativeDatasourceIT.java
@@ -1,4 +1,4 @@
-package com.redhat.jfr.tests;
+package io.cryostat.jfr.datasource.tests;
 
 import io.quarkus.test.junit.NativeImageTest;
 


### PR DESCRIPTION
This simply renames the Maven group ID and package names to better match the Cryostat project. Some imports are cleaned up as well.