### PR TITLE
Use AdoptOpenJDK Maven repo for JMC core

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ This demonstrates how a simple json data source can be used in Grafana to read t
 
 ### Dependencies
 
-This project depends on JMC Core libraries which are acquired from the sonatype repositories. They can also be built from the 'core' maven project at:
-```
-https://github.com/openjdk/jmc7
-```
-
 For native image support, graalvm 20.3.0 (Java 11 version) is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
 ```
 https://github.com/graalvm/graalvm-ce-builds/releases

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <junit.version>5.5.1</junit.version>
     <rest-assured.version>3.0.0</rest-assured.version>
 
-    <jmc.core.version>7.1.0-SNAPSHOT</jmc.core.version>
+    <jmc.core.version>7.1.1</jmc.core.version>
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
@@ -81,14 +81,10 @@
 
   <repositories>
     <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>oss.sonatype.org-snapshot</id>
-      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>adopt</id>
+      <name>AdoptOpenJDK</name>
+      <url>https://adoptopenjdk.jfrog.io/adoptopenjdk/jmc-libs</url>
+      <layout>default</layout>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Similar to https://github.com/cryostatio/cryostat-core/pull/80, we can use the AdoptOpenJDK Maven repo for released JMC core artifacts.