### PR TITLE
Use actions/cache for CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,11 +17,10 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-    - uses: skjolber/maven-cache-github-action@v1
+    - uses: actions/cache@v2
       with:
-        step: restore
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - run: mvn -B -U clean verify
-    - uses: skjolber/maven-cache-github-action@v1
-      with:
-        step: save
-


### PR DESCRIPTION
This should resolve a problem with CI adding a `-javaagent` argument to `MAVEN_OPTS` that Quarkus doesn't recognize:
https://github.com/quarkusio/quarkus/issues/16862