### PR TITLE
fix(application.properties): increase default http max-body-size

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 quarkus.http.body.uploads-directory=${java.io.tmpdir}${file.separator}jfr-file-uploads
+quarkus.http.limits.max-body-size=10G


### PR DESCRIPTION
Clean backport of #84 to v2

* fix(application.properties): increase default http max-body-size

* Document webserver HTTP body size limit