### PR TITLE
Fix(jfr): Fix IO operation blocking main thread

### DIFF
--- a/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
@@ -91,14 +91,16 @@ public class JfrResource {
     HttpServerResponse response = context.response();
     setHeaders(response);
 
-    StringBuilder responseBuilder = new StringBuilder();
+    final StringBuilder responseBuilder = new StringBuilder();
     
     context.vertx().executeBlocking(
       future -> {
-      uploadFiles(context.fileUploads(), responseBuilder);
-      future.complete();
+        uploadFiles(context.fileUploads(), responseBuilder);
+        future.complete();
     }, false, 
-      result -> response.end(responseBuilder.toString())
+      result -> {
+        response.end(responseBuilder.toString());
+      }
     );
   }
 


### PR DESCRIPTION
Fixes #88 

Fixes main thread being blocked when performing long IO operations in routes: `/set`, `/upload`, `/load`.