### PR TITLE
chore(test): fix typo of datasource test class

### DIFF
--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -25,7 +25,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @QuarkusTest
-public class DatasouceTest {
+public class DatasourceTest {
     @InjectMock FileSystemService fsService;
 
     @AfterEach


### PR DESCRIPTION
Fixes #113 

Fix typo in datasource test class name. 