### PR TITLE
fix(headers): correct headers for endpoints

### DIFF
--- a/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/JfrResource.java
@@ -37,23 +37,23 @@ public class JfrResource {
 
     @Inject FileSystemService fsService;
 
-    @Route(path = "/")
+    @Route(path = "/", methods = HttpMethod.GET)
     void root(RoutingContext context) {
         HttpServerResponse response = context.response();
         response.end();
     }
 
-    @Route(path = "/search")
+    @Route(path = "/search", methods = HttpMethod.GET)
     void search(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "application/json", "GET");
         response.end(recordingService.search());
     }
 
-    @Route(path = "/query")
+    @Route(path = "/query", methods = HttpMethod.POST)
     void query(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "application/json", "POST");
         try {
             JsonObject body = context.getBodyAsJson();
             if (body != null && !body.isEmpty()) {
@@ -69,18 +69,18 @@ public class JfrResource {
         response.end("Error: invalid query body");
     }
 
-    @Route(path = "/annotations")
+    @Route(path = "/annotations", methods = HttpMethod.GET)
     void annotations(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "GET");
         response.end(recordingService.annotations());
     }
 
-    @Route(path = "/set")
+    @Route(path = "/set", methods = HttpMethod.POST)
     @Blocking
     void set(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "POST");
 
         String file = context.getBodyAsString();
         String filePath = jfrDir + File.separator + file;
@@ -88,11 +88,11 @@ public class JfrResource {
         setFile(filePath, file, response, new StringBuilder());
     }
 
-    @Route(path = "/upload")
+    @Route(path = "/upload", methods = HttpMethod.POST)
     @Blocking
     void upload(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "POST");
 
         final StringBuilder responseBuilder = new StringBuilder();
 
@@ -100,11 +100,11 @@ public class JfrResource {
         response.end(responseBuilder.toString());
     }
 
-    @Route(path = "/load")
+    @Route(path = "/load", methods = HttpMethod.POST)
     @Blocking
     void load(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "POST");
 
         final StringBuilder responseBuilder = new StringBuilder();
 
@@ -114,10 +114,10 @@ public class JfrResource {
         setFile(filePath, lastFile, response, responseBuilder);
     }
 
-    @Route(path = "/list")
+    @Route(path = "/list", methods = HttpMethod.GET)
     void list(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "GET");
 
         try {
             StringBuilder responseBuilder = new StringBuilder();
@@ -135,10 +135,10 @@ public class JfrResource {
         }
     }
 
-    @Route(path = "/current")
+    @Route(path = "/current", methods = HttpMethod.GET)
     void current(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "GET");
 
         LOGGER.info("Current: " + loadedFile);
         response.end(loadedFile + System.lineSeparator());
@@ -148,7 +148,7 @@ public class JfrResource {
     @Blocking
     void deleteAll(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "DELETE");
 
         final StringBuilder stringBuilder = new StringBuilder();
         try {
@@ -168,7 +168,7 @@ public class JfrResource {
     @Blocking
     void delete(RoutingContext context) {
         HttpServerResponse response = context.response();
-        setHeaders(response);
+        setHeaders(response, "text/plain", "DELETE");
 
         String fileName = context.getBodyAsString();
         if (fileName == null || fileName.isEmpty()) {
@@ -292,10 +292,10 @@ public class JfrResource {
         }
     }
 
-    private void setHeaders(HttpServerResponse response) {
-        response.putHeader("content-type", "application/json");
+    private void setHeaders(HttpServerResponse response, String contentType, String allowedMethod) {
+        response.putHeader("content-type", contentType);
+        response.putHeader("Access-Control-Allow-Methods", allowedMethod);
         response.putHeader("Access-Control-Allow-Origin", "*");
-        response.putHeader("Access-Control-Allow-Methods", "POST");
         response.putHeader("Access-Control-Allow-Headers", "accept, content-type");
     }
 }

--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -323,12 +322,8 @@ public class DatasourceTest {
                             @Override
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
-                                final List<Path> files = new ArrayList<>();
                                 Path dir = invocation.getArgument(0);
-                                for (Path file : Files.list(dir).collect(Collectors.toList())) {
-                                    files.add(file);
-                                }
-                                return files;
+                                return Files.list(dir).collect(Collectors.toList());
                             }
                         });
         Mockito.when(fsService.isRegularFile(Mockito.any(Path.class)))
@@ -412,12 +407,8 @@ public class DatasourceTest {
                             @Override
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
-                                final List<Path> files = new ArrayList<>();
                                 Path dir = invocation.getArgument(0);
-                                for (Path file : Files.list(dir).collect(Collectors.toList())) {
-                                    files.add(file);
-                                }
-                                return files;
+                                return Files.list(dir).collect(Collectors.toList());
                             }
                         });
         Mockito.when(fsService.isRegularFile(Mockito.any(Path.class)))
@@ -786,7 +777,14 @@ public class DatasourceTest {
                 .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
 
         Mockito.when(fsService.isDirectory(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -798,11 +796,15 @@ public class DatasourceTest {
                             }
                         });
         Mockito.when(fsService.pathOf(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(
-                        Path.of(
-                                System.getProperty("java.io.tmpdir"),
-                                "jfr-file-uploads",
-                                "jmc.cpu.jfr"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String dir = invocation.getArgument(0);
+                                String fileName = invocation.getArgument(1);
+                                return Path.of(dir, fileName);
+                            }
+                        });
 
         Mockito.when(fsService.deleteIfExists(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -829,7 +831,14 @@ public class DatasourceTest {
     @Test
     public void testDeleteFileNotExist() throws Exception {
         Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
 
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -850,11 +859,15 @@ public class DatasourceTest {
                             }
                         });
         Mockito.when(fsService.pathOf(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(
-                        Path.of(
-                                System.getProperty("java.io.tmpdir"),
-                                "jfr-file-uploads",
-                                "jmc.cpu.jfr"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String dir = invocation.getArgument(0);
+                                String fileName = invocation.getArgument(1);
+                                return Path.of(dir, fileName);
+                            }
+                        });
 
         Mockito.when(fsService.deleteIfExists(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -924,7 +937,14 @@ public class DatasourceTest {
                 .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
 
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -945,11 +965,15 @@ public class DatasourceTest {
                             }
                         });
         Mockito.when(fsService.pathOf(Mockito.anyString(), Mockito.anyString()))
-                .thenReturn(
-                        Path.of(
-                                System.getProperty("java.io.tmpdir"),
-                                "jfr-file-uploads",
-                                "jmc.cpu.jfr"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String dir = invocation.getArgument(0);
+                                String fileName = invocation.getArgument(1);
+                                return Path.of(dir, fileName);
+                            }
+                        });
 
         Mockito.when(fsService.deleteIfExists(Mockito.any(Path.class)))
                 .thenThrow(new IOException());
@@ -1013,7 +1037,14 @@ public class DatasourceTest {
                 .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
 
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -1039,15 +1070,8 @@ public class DatasourceTest {
                             @Override
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
-                                final List<Path> files = new ArrayList<>();
-                                Path dir =
-                                        Path.of(
-                                                System.getProperty("java.io.tmpdir"),
-                                                "jfr-file-uploads");
-                                for (Path file : Files.list(dir).collect(Collectors.toList())) {
-                                    files.add(file);
-                                }
-                                return files;
+                                Path dir = invocation.getArgument(0);
+                                return Files.list(dir).collect(Collectors.toList());
                             }
                         });
         Mockito.when(fsService.isRegularFile(Mockito.any(Path.class)))
@@ -1165,15 +1189,8 @@ public class DatasourceTest {
                             @Override
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
-                                final List<Path> files = new ArrayList<>();
-                                Path dir =
-                                        Path.of(
-                                                System.getProperty("java.io.tmpdir"),
-                                                "jfr-file-uploads");
-                                for (Path file : Files.list(dir).collect(Collectors.toList())) {
-                                    files.add(file);
-                                }
-                                return files;
+                                Path dir = invocation.getArgument(0);
+                                return Files.list(dir).collect(Collectors.toList());
                             }
                         });
         Mockito.when(fsService.isRegularFile(Mockito.any(Path.class)))

--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -48,13 +49,21 @@ public class DatasourceTest {
     @Order(1)
     @Test
     public void testGet() throws Exception {
-        given().when().get("/").then().statusCode(200).body(is(""));
+        given().when().get("/").then().statusCode(200).body(is("")).headers(Collections.emptyMap());
     }
 
     @Order(2)
     @Test
-    public void testGetCurrentEndpoint() {
-        given().when().get("/current").then().statusCode(200).body(is(System.lineSeparator()));
+    public void testGetCurrent() {
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(System.lineSeparator()))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -92,7 +101,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -130,13 +148,39 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "Set: jmc.cpu.jfr" + System.lineSeparator();
-        given().body("jmc.cpu.jfr").when().post("/set").then().statusCode(200).body(is(expected));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .post("/set")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "jmc.cpu.jfr" + System.lineSeparator();
-        given().when().get("/current").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -177,10 +221,27 @@ public class DatasourceTest {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "jmc.cpu.jfr" + System.lineSeparator();
-        given().when().get("/current").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -218,7 +279,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
                 .thenAnswer(
@@ -273,26 +343,51 @@ public class DatasourceTest {
         ;
 
         expected = "jmc.cpu.jfr" + System.lineSeparator();
-        given().when().get("/list").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "Set: jmc.cpu.jfr" + System.lineSeparator();
-        given().body("jmc.cpu.jfr").when().post("/set").then().statusCode(200).body(is(expected));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .post("/set")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "**jmc.cpu.jfr**" + System.lineSeparator();
-        given().when().get("/list").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
     public void testGetListEmpty() throws Exception {
-      Mockito.when(fsService.pathOf(Mockito.anyString()))
-      .thenAnswer(
-              new Answer<Path>() {
-                  @Override
-                  public Path answer(InvocationOnMock invocation) throws IOException {
-                      String target = invocation.getArgument(0);
-                      return Path.of(target);
-                  }
-              });
+        Mockito.when(fsService.pathOf(Mockito.anyString()))
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
                         new Answer<Boolean>() {
@@ -336,7 +431,15 @@ public class DatasourceTest {
                         });
 
         String expected = "";
-        given().when().get("/list").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -374,13 +477,39 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "Set: jmc.cpu.jfr" + System.lineSeparator();
-        given().body("jmc.cpu.jfr").when().post("/set").then().statusCode(200).body(is(expected));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .post("/set")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "jmc.cpu.jfr" + System.lineSeparator();
-        given().when().get("/current").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.isDirectory(Mockito.any(Path.class)))
                 .thenAnswer(
@@ -408,9 +537,26 @@ public class DatasourceTest {
                             }
                         });
 
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(204).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(204)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
-        given().when().get("/current").then().statusCode(200).body(is(System.lineSeparator()));
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(System.lineSeparator()))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -444,12 +590,29 @@ public class DatasourceTest {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File outputFile = new File("src/test/resources/search.output.txt");
         assertTrue(outputFile.exists());
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().when().get("/search").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/search")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -483,7 +646,16 @@ public class DatasourceTest {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File inputFile = new File("src/test/resources/query.timeseries.input.txt");
         assertTrue(inputFile.exists());
@@ -493,7 +665,16 @@ public class DatasourceTest {
 
         assertTrue(outputFile.exists());
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().body(input).when().post("/query").then().statusCode(200).body(is(expected));
+        given().body(input)
+                .when()
+                .post("/query")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -527,7 +708,16 @@ public class DatasourceTest {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File inputFile = new File("src/test/resources/query.table.input.txt");
         assertTrue(inputFile.exists());
@@ -537,7 +727,16 @@ public class DatasourceTest {
 
         assertTrue(outputFile.exists());
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().body(input).when().post("/query").then().statusCode(200).body(is(expected));
+        given().body(input)
+                .when()
+                .post("/query")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -575,7 +774,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
                 .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
@@ -606,7 +814,16 @@ public class DatasourceTest {
                             }
                         });
 
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(204).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(204)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -648,7 +865,16 @@ public class DatasourceTest {
                                 return Files.deleteIfExists(target);
                             }
                         });
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(404).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(404)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -686,7 +912,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
                 .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
@@ -719,7 +954,16 @@ public class DatasourceTest {
         Mockito.when(fsService.deleteIfExists(Mockito.any(Path.class)))
                 .thenThrow(new IOException());
 
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(500).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(500)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -757,7 +1001,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
                 .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
@@ -819,8 +1072,24 @@ public class DatasourceTest {
                 .delete(Mockito.any(Path.class));
 
         expected = "Deleted: jmc.cpu.jfr" + System.lineSeparator();
-        given().when().delete("/delete_all").then().statusCode(200).body(is(expected));
-        given().when().delete("/delete_all").then().statusCode(200).body(is(""));
+        given().when()
+                .delete("/delete_all")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
+        given().when()
+                .delete("/delete_all")
+                .then()
+                .statusCode(200)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -858,7 +1127,16 @@ public class DatasourceTest {
                         });
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
                 .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
@@ -909,7 +1187,15 @@ public class DatasourceTest {
                         });
         doThrow(new IOException()).when(fsService).delete(Mockito.any(Path.class));
 
-        given().when().delete("/delete_all").then().statusCode(500).body(is(""));
+        given().when()
+                .delete("/delete_all")
+                .then()
+                .statusCode(500)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test

--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -903,4 +903,28 @@ public class DatasourceTest {
 
         given().when().delete("/delete_all").then().statusCode(500).body(is(""));
     }
+
+    @Test
+    public void testNotAllowedMethods() {
+        given().when().post("/").then().statusCode(405);
+        given().when().post("/search").then().statusCode(405);
+        given().body("{targets: [], range: { from: '', to: ''}}")
+                .header("content-type", "application/json")
+                .when()
+                .get("/query")
+                .then()
+                .statusCode(405);
+        given().when().post("/annotations").then().statusCode(405);
+        given().body("jmc.cpu.jfr").when().get("/set").then().statusCode(405);
+
+        File jfrFile = new File("src/test/resources/jmc.cpu.jfr");
+        assertTrue(jfrFile.exists());
+
+        given().multiPart(jfrFile).when().get("/upload").then().statusCode(405);
+        given().multiPart(jfrFile).when().get("/load").then().statusCode(405);
+        given().when().post("/list").then().statusCode(405);
+        given().when().post("/current").then().statusCode(405);
+        given().when().post("/delete_all").then().statusCode(405);
+        given().body("jmc.cpu.jfr").when().post("/delete").then().statusCode(405);
+    }
 }

--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -467,22 +467,14 @@ public class DatasourceTest {
                             }
                         });
 
-        String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
+        String expected =
+                "Uploaded: jmc.cpu.jfr"
+                        + System.lineSeparator()
+                        + "Set: jmc.cpu.jfr"
+                        + System.lineSeparator();
         given().multiPart(jfrFile)
                 .when()
-                .post("/upload")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"))
-                .header("Access-Control-Allow-Methods", is("POST"))
-                .header("Access-Control-Allow-Origin", is("*"))
-                .header("Access-Control-Allow-Headers", is("accept, content-type"));
-
-        expected = "Set: jmc.cpu.jfr" + System.lineSeparator();
-        given().body("jmc.cpu.jfr")
-                .when()
-                .post("/set")
+                .post("/load")
                 .then()
                 .statusCode(200)
                 .body(is(expected))

--- a/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/DatasourceTest.java
@@ -221,7 +221,14 @@ public class DatasourceTest {
         given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
 
         Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+                .thenAnswer(
+                        new Answer<Path>() {
+                            @Override
+                            public Path answer(InvocationOnMock invocation) throws IOException {
+                                String target = invocation.getArgument(0);
+                                return Path.of(target);
+                            }
+                        });
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
                         new Answer<Boolean>() {
@@ -247,10 +254,7 @@ public class DatasourceTest {
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
                                 final List<Path> files = new ArrayList<>();
-                                Path dir =
-                                        Path.of(
-                                                System.getProperty("java.io.tmpdir"),
-                                                "jfr-file-uploads");
+                                Path dir = invocation.getArgument(0);
                                 for (Path file : Files.list(dir).collect(Collectors.toList())) {
                                     files.add(file);
                                 }
@@ -280,8 +284,15 @@ public class DatasourceTest {
 
     @Test
     public void testGetListEmpty() throws Exception {
-        Mockito.when(fsService.pathOf(Mockito.anyString()))
-                .thenReturn(Path.of(System.getProperty("java.io.tmpdir"), "jfr-file-uploads"));
+      Mockito.when(fsService.pathOf(Mockito.anyString()))
+      .thenAnswer(
+              new Answer<Path>() {
+                  @Override
+                  public Path answer(InvocationOnMock invocation) throws IOException {
+                      String target = invocation.getArgument(0);
+                      return Path.of(target);
+                  }
+              });
         Mockito.when(fsService.exists(Mockito.any(Path.class)))
                 .thenAnswer(
                         new Answer<Boolean>() {
@@ -307,10 +318,7 @@ public class DatasourceTest {
                             public List<Path> answer(InvocationOnMock invocation)
                                     throws IOException {
                                 final List<Path> files = new ArrayList<>();
-                                Path dir =
-                                        Path.of(
-                                                System.getProperty("java.io.tmpdir"),
-                                                "jfr-file-uploads");
+                                Path dir = invocation.getArgument(0);
                                 for (Path file : Files.list(dir).collect(Collectors.toList())) {
                                     files.add(file);
                                 }

--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Collections;
 
 import io.quarkus.test.junit.NativeImageTest;
 import org.junit.jupiter.api.AfterEach;
@@ -29,7 +30,7 @@ public class NativeDatasourceIT {
 
     @Test
     public void testGet() throws Exception {
-        given().when().get("/").then().statusCode(200).body(is(""));
+        given().when().get("/").then().statusCode(200).body(is("")).headers(Collections.emptyMap());
     }
 
     @Test
@@ -38,7 +39,16 @@ public class NativeDatasourceIT {
         assertTrue(jfrFile.exists());
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -47,10 +57,28 @@ public class NativeDatasourceIT {
         assertTrue(jfrFile.exists());
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "Set: jmc.cpu.jfr" + System.lineSeparator();
-        given().body("jmc.cpu.jfr").when().post("/set").then().statusCode(200).body(is(expected));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .post("/set")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -63,7 +91,16 @@ public class NativeDatasourceIT {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -72,16 +109,41 @@ public class NativeDatasourceIT {
         assertTrue(jfrFile.exists());
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "jmc.cpu.jfr" + System.lineSeparator();
-        given().when().get("/list").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
     public void testGetListEmpty() throws Exception {
         String expected = "";
-        given().when().get("/list").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -94,13 +156,30 @@ public class NativeDatasourceIT {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File outputFile = new File("src/test/resources/search.output.txt");
         assertTrue(outputFile.exists());
 
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().when().get("/search").then().statusCode(200).body(is(expected));
+        given().when()
+                .get("/search")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("GET"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -113,7 +192,16 @@ public class NativeDatasourceIT {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File inputFile = new File("src/test/resources/query.timeseries.input.txt");
         assertTrue(inputFile.exists());
@@ -123,7 +211,16 @@ public class NativeDatasourceIT {
 
         assertTrue(outputFile.exists());
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().body(input).when().post("/query").then().statusCode(200).body(is(expected));
+        given().body(input)
+                .when()
+                .post("/query")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -136,7 +233,16 @@ public class NativeDatasourceIT {
                         + System.lineSeparator()
                         + "Set: jmc.cpu.jfr"
                         + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/load").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         File inputFile = new File("src/test/resources/query.table.input.txt");
         assertTrue(inputFile.exists());
@@ -146,7 +252,16 @@ public class NativeDatasourceIT {
 
         assertTrue(outputFile.exists());
         expected = new String(Files.readAllBytes(outputFile.toPath()));
-        given().body(input).when().post("/query").then().statusCode(200).body(is(expected));
+        given().body(input)
+                .when()
+                .post("/query")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("application/json"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -155,14 +270,41 @@ public class NativeDatasourceIT {
         assertTrue(jfrFile.exists());
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(204).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(204)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
     public void testDeleteFileNotExist() throws Exception {
-        given().body("jmc.cpu.jfr").when().delete("/delete").then().statusCode(404).body(is(""));
+        given().body("jmc.cpu.jfr")
+                .when()
+                .delete("/delete")
+                .then()
+                .statusCode(404)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test
@@ -171,11 +313,36 @@ public class NativeDatasourceIT {
         assertTrue(jfrFile.exists());
 
         String expected = "Uploaded: jmc.cpu.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile).when().post("/upload").then().statusCode(200).body(is(expected));
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("POST"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
 
         expected = "Deleted: jmc.cpu.jfr" + System.lineSeparator();
-        given().when().delete("/delete_all").then().statusCode(200).body(is(expected));
-        given().when().delete("/delete_all").then().statusCode(200).body(is(""));
+        given().when()
+                .delete("/delete_all")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
+        given().when()
+                .delete("/delete_all")
+                .then()
+                .statusCode(200)
+                .body(is(""))
+                .header("content-type", is("text/plain"))
+                .header("Access-Control-Allow-Methods", is("DELETE"))
+                .header("Access-Control-Allow-Origin", is("*"))
+                .header("Access-Control-Allow-Headers", is("accept, content-type"));
     }
 
     @Test

--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -177,4 +177,28 @@ public class NativeDatasourceIT {
         given().when().delete("/delete_all").then().statusCode(200).body(is(expected));
         given().when().delete("/delete_all").then().statusCode(200).body(is(""));
     }
+
+    @Test
+    public void testNotAllowedMethods() {
+        given().when().post("/").then().statusCode(405);
+        given().when().post("/search").then().statusCode(405);
+        given().body("{targets: [], range: { from: '', to: ''}}")
+                .header("content-type", "application/json")
+                .when()
+                .get("/query")
+                .then()
+                .statusCode(405);
+        given().when().post("/annotations").then().statusCode(405);
+        given().body("jmc.cpu.jfr").when().get("/set").then().statusCode(405);
+
+        File jfrFile = new File("src/test/resources/jmc.cpu.jfr");
+        assertTrue(jfrFile.exists());
+
+        given().multiPart(jfrFile).when().get("/upload").then().statusCode(405);
+        given().multiPart(jfrFile).when().get("/load").then().statusCode(405);
+        given().when().post("/list").then().statusCode(405);
+        given().when().post("/current").then().statusCode(405);
+        given().when().post("/delete_all").then().statusCode(405);
+        given().body("jmc.cpu.jfr").when().post("/delete").then().statusCode(405);
+    }
 }


### PR DESCRIPTION
Fixes #123 
Related to #122 

Correct headers for endpoints since some do not return JSON-formatted response but still set `application/json` header.
Added tests for `/current` endpoint to native image while cleaning up tests.

I also enforce allowed VERB for each endpoints.