### PR TITLE
feat(uploads): allow overwrite existing jfr files

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ $ curl "localhost:8080/"
 
 Expects a JFR file upload. Used to upload a JFR file to the server. Responds with the uploaded filename.
 
+If `overwrite` query parameter is set to `true`, the uploaded file will overwrite the existing one with the same name.
+
 The webserver sets a default maximum file upload size of 10GB
 (`application.properties`: `quarkus.http.limits.max-body-size=10G`).
 This can be overridden on a deployed instance by setting the environment variable
@@ -130,6 +132,8 @@ $ curl -X POST --data "some-file" "localhost:8080/set"
 #### POST /load
 
 Expects a JFR file upload. Performs `Upload` and `Set` in sequence. Responds with the uploaded and selected filename.
+
+If `overwrite` query parameter is set to `true`, the uploaded file will overwrite the existing one with the same name.
 
 The webserver sets a default maximum file upload size. If the file to be
 uploaded exceeds this size then either the limit can be raised or the `/load`

--- a/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
@@ -156,7 +156,7 @@ public class Datasource {
 
         final StringBuilder responseBuilder = new StringBuilder();
 
-        boolean overwrite = Boolean.valueOf(extractQueryParam(context, "overwrite", "false"));
+        boolean overwrite = Boolean.parseBoolean(extractQueryParam(context, "overwrite", "false"));
         uploadFiles(context.fileUploads(), responseBuilder, overwrite);
         response.end(responseBuilder.toString());
     }
@@ -171,7 +171,7 @@ public class Datasource {
 
         final StringBuilder responseBuilder = new StringBuilder();
 
-        boolean overwrite = Boolean.valueOf(extractQueryParam(context, "overwrite", "false"));
+        boolean overwrite = Boolean.parseBoolean(extractQueryParam(context, "overwrite", "false"));
         String lastFile = uploadFiles(context.fileUploads(), responseBuilder, overwrite);
         String filePath = jfrDir + File.separator + lastFile;
 

--- a/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
@@ -227,6 +227,7 @@ public class Datasource {
                 stringBuilder.append("Deleted: " + deletedFile);
                 stringBuilder.append(System.lineSeparator());
             }
+            setLoadedFile(UNSET_FILE);
             response.end(stringBuilder.toString());
         } catch (IOException e) {
             LOGGER.error(e.getMessage(), e);
@@ -248,6 +249,9 @@ public class Datasource {
         } else {
             try {
                 deleteFile(fileName);
+                if (fileName.equals(loadedFile)) {
+                    setLoadedFile(UNSET_FILE);
+                }
                 response.setStatusCode(204);
             } catch (FileNotFoundException e) {
                 LOGGER.error(e.getMessage(), e);

--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -139,6 +139,59 @@ public class NativeDatasourceIT {
     }
 
     @Test
+    @Order(5)
+    public void testGetList() throws Exception {
+        File jfrFile = new File("src/test/resources/recording.jfr");
+        assertTrue(jfrFile.exists());
+
+        String expected = "Uploaded: recording.jfr" + System.lineSeparator();
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        expected = "recording.jfr" + System.lineSeparator();
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        expected = "Set: recording.jfr" + System.lineSeparator();
+        given().body("recording.jfr")
+                .when()
+                .post("/set")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        expected = "**recording.jfr**" + System.lineSeparator();
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+    }
+
+    @Test
+    @Order(6)
+    public void testGetListEmpty() throws Exception {
+        String expected = "";
+        given().when()
+                .get("/list")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+    }
+
+    @Test
     public void testPostSet() throws Exception {
         File jfrFile = new File("src/test/resources/recording.jfr");
         assertTrue(jfrFile.exists());
@@ -227,57 +280,6 @@ public class NativeDatasourceIT {
         expected = "recording.jfr" + System.lineSeparator();
         given().when()
                 .get("/current")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"));
-    }
-
-    @Test
-    public void testGetList() throws Exception {
-        File jfrFile = new File("src/test/resources/recording.jfr");
-        assertTrue(jfrFile.exists());
-
-        String expected = "Uploaded: recording.jfr" + System.lineSeparator();
-        given().multiPart(jfrFile)
-                .when()
-                .post("/upload")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"));
-
-        expected = "recording.jfr" + System.lineSeparator();
-        given().when()
-                .get("/list")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"));
-
-        expected = "Set: recording.jfr" + System.lineSeparator();
-        given().body("recording.jfr")
-                .when()
-                .post("/set")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"));
-
-        expected = "**recording.jfr**" + System.lineSeparator();
-        given().when()
-                .get("/list")
-                .then()
-                .statusCode(200)
-                .body(is(expected))
-                .header("content-type", is("text/plain"));
-    }
-
-    @Test
-    public void testGetListEmpty() throws Exception {
-        String expected = "";
-        given().when()
-                .get("/list")
                 .then()
                 .statusCode(200)
                 .body(is(expected))

--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -44,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
 
 import io.quarkus.test.junit.NativeImageTest;
@@ -87,6 +88,7 @@ public class NativeDatasourceIT {
     }
 
     @Test
+    @Order(3)
     public void testPostUpload() throws Exception {
         File jfrFile = new File("src/test/resources/recording.jfr");
         assertTrue(jfrFile.exists());
@@ -95,6 +97,41 @@ public class NativeDatasourceIT {
         given().multiPart(jfrFile)
                 .when()
                 .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+    }
+
+    @Test
+    @Order(4)
+    public void testPostUploadWithOverwrite() throws Exception {
+        File jfrFile = new File("src/test/resources/recording.jfr");
+        assertTrue(jfrFile.exists());
+
+        String expected = "Uploaded: recording.jfr" + System.lineSeparator();
+        given().multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        // Should return the same filename
+        given().queryParam("overwrite", Arrays.asList("true"))
+                .multiPart(jfrFile)
+                .when()
+                .post("/upload")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        // There should only be 1 file when /list
+        expected = "recording.jfr" + System.lineSeparator();
+        given().when()
+                .get("/list")
                 .then()
                 .statusCode(200)
                 .body(is(expected))
@@ -144,6 +181,42 @@ public class NativeDatasourceIT {
                         + "Set: recording.jfr"
                         + System.lineSeparator();
         given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        expected = "recording.jfr" + System.lineSeparator();
+        given().when()
+                .get("/current")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+    }
+
+    @Test
+    public void testPostLoadWithOverwrite() throws Exception {
+        File jfrFile = new File("src/test/resources/recording.jfr");
+        assertTrue(jfrFile.exists());
+
+        String expected =
+                "Uploaded: recording.jfr"
+                        + System.lineSeparator()
+                        + "Set: recording.jfr"
+                        + System.lineSeparator();
+        given().multiPart(jfrFile)
+                .when()
+                .post("/load")
+                .then()
+                .statusCode(200)
+                .body(is(expected))
+                .header("content-type", is("text/plain"));
+
+        given().queryParam("overwrite", Arrays.asList("true"))
+                .multiPart(jfrFile)
                 .when()
                 .post("/load")
                 .then()


### PR DESCRIPTION
Fixes #152 

Route `/upload` and `load` now allows setting query parameter `?overwrite=true`, which will overwrite any existing files of the same name.

Tests need a bit adjusting since if `/load` route is tested first, selected files will have the form `**file-name**`.