### PR TITLE
ci(deps): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "cryostatio/reviewers"
+    labels:
+      - "dependencies"
+      - "chore"
+      - "safe-to-test"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "docker"
+    directory: "src/main/docker"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "cryostatio/reviewers"
+    labels:
+      - "dependencies"
+      - "chore"
+      - "safe-to-test"


### PR DESCRIPTION
This adds Dependabot config to this repo, similar to how we did in `-report`.

Fixes #145 