### PR TITLE
build(quarkus): migrate to quarkus 2.13

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -40,7 +40,7 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - run: mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17 clean verify
+    - run: mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17 clean verify
     - run: podman build -f src/main/docker/Dockerfile.native -t "quay.io/cryostat/$IMAGE_NAME:$IMAGE_VERSION" .
       env:
         IMAGE_NAME: ${{ needs.get-pom-properties.outputs.image-name }}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This demonstrates how a simple json data source can be used in Grafana to read t
 
 ### Dependencies
 
-For native image support, graalvm 21.3.0 (Java 17 version) is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
+For native image support, graalvm 22.3 (Java 17 version) is needed with path to it's directory set via environment variable `GRAALVM_HOME`. This can be downloaded from:
 ```
 https://github.com/graalvm/graalvm-ce-builds/releases
 ```
@@ -44,7 +44,7 @@ Native image builds may use more than 4G of RAM to complete.
 To build a native image within a container, for a consistent environment:
 ```bash
 mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman \
--Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:21.3-java17 \
+-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17 \
 clean verify
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.7.6.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.7.6.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.8.3.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.8.3.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.9.2.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.10.4.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.10.4.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.10.4.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.11.3.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.11.3.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.11.3.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.12.3.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.12.3.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.12.3.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.12.3.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.13.7.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.8.3.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.8.3.Final</quarkus-plugin.version>
+    <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
+    <quarkus-plugin.version>2.9.2.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.1.2</org.owasp.dependency.check.version>
 

--- a/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
@@ -44,7 +44,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -89,7 +88,7 @@ public class Datasource {
             produces = {ReactiveRoutes.APPLICATION_JSON})
     void search(RoutingContext context) {
         HttpServerResponse response = context.response();
-        JsonObject body = context.getBodyAsJson();
+        JsonObject body = context.body().asJsonObject();
         try {
             if (body != null && !body.isEmpty()) {
                 LOGGER.info(body.toString());
@@ -109,7 +108,7 @@ public class Datasource {
     void query(RoutingContext context) {
         HttpServerResponse response = context.response();
         try {
-            JsonObject body = context.getBodyAsJson();
+            JsonObject body = context.body().asJsonObject();
             if (body != null && !body.isEmpty()) {
                 LOGGER.info(body.toString());
                 Query query = new Query(body);
@@ -140,7 +139,7 @@ public class Datasource {
     void set(RoutingContext context) {
         HttpServerResponse response = context.response();
 
-        String file = context.getBodyAsString();
+        String file = context.body().asString();
         String filePath = jfrDir + File.separator + file;
 
         setFile(filePath, file, response, new StringBuilder());
@@ -243,7 +242,7 @@ public class Datasource {
     void delete(RoutingContext context) {
         HttpServerResponse response = context.response();
 
-        String fileName = context.getBodyAsString();
+        String fileName = context.body().asString();
         if (fileName == null || fileName.isEmpty()) {
             response.setStatusCode(400);
         } else {
@@ -278,7 +277,7 @@ public class Datasource {
     }
 
     private String uploadFiles(
-            Set<FileUpload> uploads, StringBuilder responseBuilder, boolean overwrite) {
+            List<FileUpload> uploads, StringBuilder responseBuilder, boolean overwrite) {
         String lastFile = "";
         for (FileUpload fileUpload : uploads) {
             Path source = fsService.pathOf(fileUpload.uploadedFileName());

--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -47,7 +47,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 @TestMethodOrder(OrderAnnotation.class)
-@NativeImageTest
+@QuarkusIntegrationTest
 public class NativeDatasourceIT {
     @AfterEach
     public void afterEachDatasourceTest() {


### PR DESCRIPTION
Fixes #164 

Migrate Quarkus to 2.13 ([2.13.7.Final](https://mvnrepository.com/artifact/io.quarkus/quarkus-bom/2.13.7.Final)). 

References:
- https://github.com/quarkusio/quarkus/wiki/Migration-Guides
- https://access.redhat.com/articles/4966181#RHBQ_2_13_x