### PR TITLE
chore(ci): use temurin distribution jdk

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - uses: actions/cache@v2
       with:
         path: ~/.m2/repository


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1401

See https://github.com/actions/setup-java#supported-distributions

Update ci to use `temurin` jdk.