### PR TITLE
test(native): trim newline from expected output

### DIFF
--- a/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
+++ b/src/test/java/io/cryostat/jfr/datasource/server/NativeDatasourceIT.java
@@ -359,7 +359,7 @@ public class NativeDatasourceIT {
                 .post("/search")
                 .then()
                 .statusCode(200)
-                .body(is(expected))
+                .body(is(expected.trim()))
                 .header("content-type", is("application/json"));
     }
 


### PR DESCRIPTION
#160 included calling `trim()` on the expected `/search` output so the file could end with a newline. This needed to be done in NativeDatasourceIT as well. 

Fixes: #185 