### PR TITLE
chore(quarkus): upgrade to Quarkus 3

### DIFF
--- a/.github/workflows/push-ci.yaml
+++ b/.github/workflows/push-ci.yaml
@@ -40,7 +40,7 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - run: mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17 clean verify
+    - run: mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman -Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17 clean verify
     - run: podman build -f src/main/docker/Dockerfile.native -t "quay.io/cryostat/$IMAGE_NAME:$IMAGE_VERSION" .
       env:
         IMAGE_NAME: ${{ needs.get-pom-properties.outputs.image-name }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Native image builds may use more than 4G of RAM to finish.
 To build a native image within a container, for a consistent environment:
 ```bash
 mvn -Pnative -Dquarkus.native.container-build=true -Dquarkus.native.container-runtime=podman \
--Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel:22.3-java17 \
+-Dquarkus.native.builder-image=quay.io/quarkus/ubi-quarkus-mandrel-builder-image:23.0-java17 \
 clean verify
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,19 +10,22 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+    <java.version>17</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+
     <maven-failsafe-plugin.version>3.1.2</maven-failsafe-plugin.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 
-    <java.version>17</java.version>
-
     <jmc.core.version>8.2.0</jmc.core.version>
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.13.7.Final</quarkus.platform.version>
-    <quarkus-plugin.version>2.13.7.Final</quarkus-plugin.version>
+    <quarkus.platform.version>3.2.4.Final</quarkus.platform.version>
+    <quarkus-plugin.version>3.2.4.Final</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>8.3.1</org.owasp.dependency.check.version>
 

--- a/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
+++ b/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
@@ -26,8 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.openjdk.jmc.common.item.IAttribute;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -55,6 +53,7 @@ import io.cryostat.jfr.datasource.utils.ArgRunnable;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
+++ b/src/main/java/io/cryostat/jfr/datasource/server/Datasource.java
@@ -24,8 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import javax.inject.Inject;
-
 import io.cryostat.jfr.datasource.events.RecordingService;
 import io.cryostat.jfr.datasource.sys.FileSystemService;
 
@@ -38,6 +36,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.FileUpload;
 import io.vertx.ext.web.RoutingContext;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/cryostat/jfr/datasource/sys/FileSystemService.java
+++ b/src/main/java/io/cryostat/jfr/datasource/sys/FileSystemService.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class FileSystemService {


### PR DESCRIPTION
Fixes #198

Upgrades Quarkus version and native-mode Mandrel builder image version. This was done with the `quarkus update` CLI tool to update the `pom.xml` and do some openrewrite substitutions for changed imports, then manually adjusting tests, README, ci YAML.

`DatasourceTest` is greatly simplified since the vast majority of the mock cases were just proxying the real method calls, so I replaced the mock with a spy and only override the cases where exception handling is tested and a specific override must be made.

Using the usual Cryostat `smoketest.sh`, this can be tested by checking out locally, building a container image, then doing `PULL_IMAGES=missing DATASOURCE_IMAGE=quay.io/cryostat/jfr-datasource:latest sh smoketest.sh`.
