### PR TITLE
build(assembly): add profile to archive Quarkus artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,32 @@
       </build>
     </profile>
     <profile>
+      <id>quarkus-app</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>${maven-assembly-plugin.version}</version>
+            <configuration>
+              <descriptors>
+                <descriptor>src/assembly/quarkus-app.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+            <executions>
+              <execution>
+                <id>assemble-quarkus-app</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>dep-check</id>
       <build>
         <plugins>

--- a/src/assembly/quarkus-app.xml
+++ b/src/assembly/quarkus-app.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 http://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>quarkus-app</id>
+  <formats>
+    <format>tar.gz</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/quarkus-app</directory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
Adds a `quarkus-app` profile that creates a tarball of the quarkus-app directory. This tarball can be used as input to a separate container image build.

Fixes: #207 