### PR TITLE
chore(events): replace deprecated getAttributes method

### DIFF
--- a/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
+++ b/src/main/java/io/cryostat/jfr/datasource/events/RecordingService.java
@@ -26,14 +26,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.openjdk.jmc.common.item.IAttribute;
+import org.openjdk.jmc.common.item.IAccessorKey;
 import org.openjdk.jmc.common.item.IItem;
 import org.openjdk.jmc.common.item.IItemCollection;
 import org.openjdk.jmc.common.item.IItemIterable;
 import org.openjdk.jmc.common.item.IMemberAccessor;
 import org.openjdk.jmc.common.item.IType;
 import org.openjdk.jmc.common.item.ItemFilters;
-import org.openjdk.jmc.common.item.ItemToolkit;
 import org.openjdk.jmc.common.unit.IQuantity;
 import org.openjdk.jmc.common.unit.IRange;
 import org.openjdk.jmc.common.unit.IUnit;
@@ -88,11 +87,16 @@ public class RecordingService {
                 IItemIterable item = i.next();
                 if (item.hasItems()) {
                     IType<IItem> type = item.getType();
-                    List<IAttribute<?>> attributes = type.getAttributes();
-                    for (IAttribute<?> attribute : attributes) {
-                        if (attribute.getIdentifier().contains("eventType")
-                                || attribute.getIdentifier().contains("startTime")
-                                || attribute.getIdentifier().contains("endTime")) {
+                    for (IAccessorKey<?> attribute : type.getAccessorKeys().keySet()) {
+                        if (attribute
+                                        .getIdentifier()
+                                        .contains(JfrAttributes.EVENT_TYPE.getIdentifier())
+                                || attribute
+                                        .getIdentifier()
+                                        .contains(JfrAttributes.START_TIME.getIdentifier())
+                                || attribute
+                                        .getIdentifier()
+                                        .contains(JfrAttributes.END_TIME.getIdentifier())) {
                             continue;
                         }
                         String name = type.getIdentifier() + "." + attribute.getIdentifier();
@@ -118,12 +122,10 @@ public class RecordingService {
         // Should be only 0 or 1 iterator as filtered by name
         for (IItemIterable itemIterable : filteredEvents) {
             IType<IItem> type = itemIterable.getType();
-            List<IAttribute<?>> attributes = type.getAttributes();
             IMemberAccessor<?, IItem> accessor = null;
-
-            for (IAttribute<?> attribute : attributes) {
+            for (IAccessorKey<?> attribute : type.getAccessorKeys().keySet()) {
                 if (targetField.equals(attribute.getIdentifier())) {
-                    accessor = ItemToolkit.accessor(attribute);
+                    accessor = type.getAccessor(attribute);
                     break;
                 }
             }
@@ -294,15 +296,12 @@ public class RecordingService {
                     // name.
                     for (IItemIterable itemIterable : filteredEvents) {
                         IType<IItem> type = itemIterable.getType();
-                        List<IAttribute<?>> attributes = type.getAttributes();
                         final Map<String, IMemberAccessor<?, IItem>> aMap = new HashMap<>();
-
-                        for (IAttribute<?> attribute : attributes) { // Attributes of the events
+                        for (IAccessorKey<?> attribute : type.getAccessorKeys().keySet()) {
                             if (eventField.equals(attribute.getIdentifier())) {
-                                aMap.put(eventField, ItemToolkit.accessor(attribute));
+                                aMap.put(eventField, type.getAccessor(attribute));
                             } else if (targetOptions.get(attribute.getIdentifier()) != null) {
-                                aMap.put(
-                                        attribute.getIdentifier(), ItemToolkit.accessor(attribute));
+                                aMap.put(attribute.getIdentifier(), type.getAccessor(attribute));
                             }
                         }
 
@@ -423,13 +422,10 @@ public class RecordingService {
                     // name.
                     for (IItemIterable itemIterable : filteredEvents) {
                         IType<IItem> type = itemIterable.getType();
-                        List<IAttribute<?>> attributes = type.getAttributes();
-
                         IMemberAccessor<?, IItem> accessor = null;
-
-                        for (IAttribute<?> attribute : attributes) { // Attributes of the events
+                        for (IAccessorKey<?> attribute : type.getAccessorKeys().keySet()) {
                             if (targetEventField.equals(attribute.getIdentifier())) {
-                                accessor = ItemToolkit.accessor(attribute);
+                                accessor = type.getAccessor(attribute);
                                 columns.forEach(
                                         (obj) -> { // Update targetField type
                                             JsonObject jsonObj = ((JsonObject) obj);


### PR DESCRIPTION
This PR addresses issue 182 [[0]](https://github.com/cryostatio/jfr-datasource/issues/182), in which there are deprecated JMC methods being used: `IType.getAttributes()` and `ItemToolkit.acessor()`.

The approach here is similar to what is found in the jmc core flightrecorder.serializers `IItemCollectionJsonSerializer` [[1]](https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/json/IItemCollectionJsonSerializer.java#L160), where the attributes are instead collected using the `accessorKeys()` on the `IType`. The accessor is then retrieved using the `IType.getAccessor()` instead of using the `ItemToolkit`.

[0] https://github.com/cryostatio/jfr-datasource/issues/182
[1] https://github.com/openjdk/jmc/blob/master/core/org.openjdk.jmc.flightrecorder.serializers/src/main/java/org/openjdk/jmc/flightrecorder/serializers/json/IItemCollectionJsonSerializer.java#L160