### PR TITLE
chore(quarkus): upgrade to 3.8 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.5</quarkus.platform.version>
+    <quarkus.platform.version>3.8.6</quarkus.platform.version>
     <quarkus-plugin.version>3.8.5</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>9.2.0</org.owasp.dependency.check.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,8 @@
 
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.12.Final</quarkus.platform.version>
-    <quarkus-plugin.version>3.2.12.Final</quarkus-plugin.version>
-    <!-- TODO Remove if Quarkus updates Netty in 3.2 -->
-    <io.netty.version>4.1.108.Final</io.netty.version>
+    <quarkus.platform.version>3.8.5</quarkus.platform.version>
+    <quarkus-plugin.version>3.8.5</quarkus-plugin.version>
 
     <org.owasp.dependency.check.version>9.2.0</org.owasp.dependency.check.version>
 
@@ -42,13 +40,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${io.netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>


### PR DESCRIPTION
- **build(deps): update to Quarkus 3.8 LTS (#316)**
- **build(deps): bump io.quarkus:quarkus-bom from 3.8.5 to 3.8.6 (#322)**

Related to https://github.com/cryostatio/cryostat/issues/688